### PR TITLE
Fix the majority of verification race conditions

### DIFF
--- a/handlers/VERIFY_USER.js
+++ b/handlers/VERIFY_USER.js
@@ -43,14 +43,23 @@ exports.run = async (client, interaction, member) => {
             ephemeral: true
         })
     }else {
+        let role = await interaction.guild.roles.fetch(process.env.VERIFIED_ROLE);
+
         let guildMember = await interaction.guild.members.fetch(threadName[1]);
         if (!guildMember) return interaction.reply({
             content: "Member is no longer apart of guild.",
             ephemeral: true
         })
     
-        let role = await interaction.guild.roles.fetch(process.env.VERIFIED_ROLE);
     
+        if (guildMember.roles.has(role)) {
+            return await interaction.reply({
+                content: `<@${threadName[1]}> was already verified`,
+                allowedMentions: {
+                    users: [client.user.id],
+                }
+            })
+        }
         // Add the verified role to the user
         guildMember.roles.add(role)
     


### PR DESCRIPTION
There is currently a high potential for race conditions when multiple verifiers attempt to verify a user at the same time. This PR fixes the majority of these cases

Data races can probably still occur in the following cases:
- If Discord is still adding the role when we fetch the user for the second time
- If we don't all verify, for example if someone does a kick and someone else does a verify

These are substantially less likely than the common case, which has happened several times now